### PR TITLE
Add build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,50 @@
+# Building webchain-miner
+
+webchain-miner does not build on GCC 4.8, which means Debian 10 Buster and possibly CentOS 7.
+
+webchain-miner does not support HTTP, so remember to pass `-DWITH_HTTPD=OFF` to `cmake`, otherwise it won't build!
+
+## Install dependencies:
+
+### Ubuntu / Debian 11 Bullseye:
+```
+sudo apt-get install git build-essential cmake libuv1-dev libssl-dev libhwloc-dev
+```
+
+### Fedora:
+```
+sudo dnf install -y git make cmake gcc gcc-c++ libstdc++-static libuv-static hwloc-devel openssl-devel
+```
+
+### Alpine:
+```
+apk add git make cmake libstdc++ gcc g++ libuv-dev openssl-dev hwloc-dev
+```
+To install hwloc-dev package you must enable testing repository in /etc/apk/repositories file.
+
+### FreeBSD
+```
+pkg install git cmake libuv openssl hwloc
+```
+
+### CentOS 8
+```
+sudo dnf install -y epel-release
+sudo yum config-manager --set-enabled PowerTools
+sudo dnf install -y git make cmake gcc gcc-c++ libstdc++-static hwloc-devel openssl-devel automake libtool autoconf
+```
+
+## Build:
+```
+git clone https://github.com/mintme-com/miner
+mkdir xmrig/build && cd xmrig/build
+cmake -DWITH_HTTPD=OFF ..
+make -j$(nproc)
+```
+
+## MacOS / Windows:
+For building on MacOS and Windows, please refer to the original XMRig build documentation:
+
+MaxOS (including Apple Silicon): https://xmrig.com/docs/miner/build/macos
+
+Windows: https://xmrig.com/docs/miner/build/windows

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,6 @@ make -j$(nproc)
 ## MacOS / Windows:
 For building on MacOS and Windows, please refer to the original XMRig build documentation:
 
-MaxOS (including Apple Silicon): https://xmrig.com/docs/miner/build/macos
+MacOS (including Apple Silicon): https://xmrig.com/docs/miner/build/macos
 
 Windows: https://xmrig.com/docs/miner/build/windows

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,7 +37,7 @@ sudo dnf install -y git make cmake gcc gcc-c++ libstdc++-static hwloc-devel open
 ## Build:
 ```
 git clone https://github.com/mintme-com/miner
-mkdir xmrig/build && cd xmrig/build
+mkdir miner/build && cd miner/build
 cmake -DWITH_HTTPD=OFF ..
 make -j$(nproc)
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,12 +1,12 @@
 # Building webchain-miner
 
-webchain-miner does not build on GCC 4.8, which means Debian 10 Buster and possibly CentOS 7.
-
 webchain-miner does not support HTTP, so remember to pass `-DWITH_HTTPD=OFF` to `cmake`, otherwise it won't build!
+
+Also, it requires a fairly modern distribution. If a distro release is specified below, that means it's confirmed to not build on the previous version.
 
 ## Install dependencies:
 
-### Ubuntu / Debian 11 Bullseye:
+### Ubuntu (see #34) / Debian 11 Bullseye:
 ```
 sudo apt-get install git build-essential cmake libuv1-dev libssl-dev libhwloc-dev
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Originally based on XMRig with changes that allow mining WEB.
 #### Table of contents
 * [Features](#features)
 * [Download](#download)
+* [Building](#building)
 * [Usage](#usage)
 * [Algorithm variations](#algorithm-variations)
 * [Common Issues](#common-issues)
@@ -25,12 +26,17 @@ Originally based on XMRig with changes that allow mining WEB.
 
 ## Download
 * Binary releases: https://github.com/webchain-network/webchain-miner/releases
-* Git tree: https://github.com/webchain-network/webchain-miner.git
-  * Clone with `git clone https://github.com/webchain-network/webchain-miner.git` :hammer: [Build instructions](https://github.com/xmrig/xmrig/wiki/Build).
+
+## Building
+* For build instructions, see [BUILDING.md](BUILDING.md) .
 
 ## Usage
+Minimal set of options:
+```
+webchain-miner -o <pool_address> -u <0xYOUR_PUBKEY> -p <password>
+```
 
-### Options
+All available options:
 ```
   -o, --url=URL            URL of mining server
   -O, --userpass=U:P       username:password pair for mining server
@@ -61,7 +67,7 @@ Originally based on XMRig with changes that allow mining WEB.
   -V, --version            output version information and exit
 ```
 
-Also you can use configuration via config file, default **config.json**. You can load multiple config files and combine it with command line options.
+* Also you can use configuration via config file, default **config.json**. You can load multiple config files and combine it with command line options.
 
 ## Common Issues
 ### HUGE PAGES unavailable


### PR DESCRIPTION
Rather than directing users to the build instructions for XMRig, we should provide our own, especially considering they are a bit different. At least for Linux/FreeBSD - I can't try MacOS and Windows, and those are a niche of a niche anyway.

Lists of dependencies take too much space to fit into README.md without ruining its brevity, so a separate file instead. There are probably not many people looking to build it instead of just downloading the binaries.